### PR TITLE
Sanitize stop grace period handling

### DIFF
--- a/packages/server/__test__/mechanizeDockerContainer.test.ts
+++ b/packages/server/__test__/mechanizeDockerContainer.test.ts
@@ -1,0 +1,56 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const inspectMock = vi.fn(() => Promise.reject(new Error("service not found")));
+const getServiceMock = vi.fn(() => ({ inspect: inspectMock }));
+const createServiceMock = vi.fn(async () => undefined);
+
+vi.mock("../src/utils/servers/remote-docker", () => ({
+        getRemoteDocker: vi.fn(async () => ({
+                getService: getServiceMock,
+                createService: createServiceMock,
+        })),
+}));
+
+import {
+        mechanizeDockerContainer,
+        type ApplicationNested,
+} from "../src/utils/builders";
+
+describe("mechanizeDockerContainer", () => {
+        beforeEach(() => {
+                inspectMock.mockClear();
+                getServiceMock.mockClear();
+                createServiceMock.mockClear();
+        });
+
+        it("passes a numeric StopGracePeriod when provided as bigint", async () => {
+                const application = {
+                        appName: "test-app",
+                        env: null,
+                        mounts: [],
+                        cpuLimit: null,
+                        memoryLimit: null,
+                        memoryReservation: null,
+                        cpuReservation: null,
+                        command: null,
+                        ports: [],
+                        sourceType: "docker",
+                        dockerImage: "example:latest",
+                        registry: null,
+                        environment: {
+                                project: { env: null },
+                                env: null,
+                        },
+                        replicas: 1,
+                        stopGracePeriodSwarm: 0n,
+                        serverId: null,
+                } as unknown as ApplicationNested;
+
+                await mechanizeDockerContainer(application);
+
+                expect(createServiceMock).toHaveBeenCalledTimes(1);
+                const [settings] = createServiceMock.mock.calls[0];
+                expect(settings.StopGracePeriod).toBe(0);
+                expect(typeof settings.StopGracePeriod).toBe("number");
+        });
+});

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -104,7 +104,8 @@
     "tailwindcss": "^3.4.17",
     "tsc-alias": "1.8.10",
     "tsx": "^4.16.2",
-    "typescript": "^5.8.3"
+    "typescript": "^5.8.3",
+    "vitest": "^1.6.1"
   },
   "packageManager": "pnpm@9.12.0",
   "engines": {

--- a/packages/server/src/utils/builders/index.ts
+++ b/packages/server/src/utils/builders/index.ts
@@ -191,9 +191,10 @@ export const mechanizeDockerContainer = async (
 				PublishedPort: port.publishedPort,
 			})),
 		},
-		UpdateConfig,
-		...(StopGracePeriod && { StopGracePeriod }),
-	};
+                UpdateConfig,
+                ...(StopGracePeriod !== undefined &&
+                        StopGracePeriod !== null && { StopGracePeriod }),
+        };
 
 	try {
 		const service = docker.getService(appName);

--- a/packages/server/src/utils/docker/utils.ts
+++ b/packages/server/src/utils/docker/utils.ts
@@ -381,25 +381,29 @@ export const calculateResources = ({
 };
 
 export const generateConfigContainer = (
-	application: Partial<ApplicationNested>,
+        application: Partial<ApplicationNested>,
 ) => {
-	const {
-		healthCheckSwarm,
-		restartPolicySwarm,
-		placementSwarm,
-		updateConfigSwarm,
-		rollbackConfigSwarm,
-		modeSwarm,
-		labelsSwarm,
-		replicas,
-		mounts,
-		networkSwarm,
-		stopGracePeriodSwarm,
-	} = application;
+        const {
+                healthCheckSwarm,
+                restartPolicySwarm,
+                placementSwarm,
+                updateConfigSwarm,
+                rollbackConfigSwarm,
+                modeSwarm,
+                labelsSwarm,
+                replicas,
+                mounts,
+                networkSwarm,
+                stopGracePeriodSwarm,
+        } = application;
 
-	const haveMounts = mounts && mounts.length > 0;
+        const sanitizedStopGracePeriodSwarm =
+                typeof stopGracePeriodSwarm === "bigint"
+                        ? Number(stopGracePeriodSwarm)
+                        : stopGracePeriodSwarm;
+        const haveMounts = mounts && mounts.length > 0;
 
-	return {
+        return {
 		...(healthCheckSwarm && {
 			HealthCheck: healthCheckSwarm,
 		}),
@@ -445,9 +449,10 @@ export const generateConfigContainer = (
 						Order: "start-first",
 					},
 				}),
-		...(stopGracePeriodSwarm && {
-			StopGracePeriod: stopGracePeriodSwarm,
-		}),
+                ...(sanitizedStopGracePeriodSwarm !== null &&
+                        sanitizedStopGracePeriodSwarm !== undefined && {
+                                StopGracePeriod: sanitizedStopGracePeriodSwarm,
+                        }),
 		...(networkSwarm
 			? {
 					Networks: networkSwarm,

--- a/packages/server/vitest.config.ts
+++ b/packages/server/vitest.config.ts
@@ -1,0 +1,18 @@
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+import { defineConfig } from "vitest/config";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+export default defineConfig({
+        test: {
+                environment: "node",
+                include: ["__test__/**/*.test.ts"],
+        },
+        resolve: {
+                alias: {
+                        "@dokploy/server": resolve(__dirname, "./src"),
+                },
+        },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -820,6 +820,9 @@ importers:
       typescript:
         specifier: ^5.8.3
         version: 5.8.3
+      vitest:
+        specifier: ^1.6.1
+        version: 1.6.1(@types/node@18.19.104)
 
 packages:
 


### PR DESCRIPTION
## Summary
- coerce the swarm stop grace period to a number before building container specs and keep zero values
- forward the sanitized StopGracePeriod in mechanizeDockerContainer
- add a vitest config and unit test that asserts StopGracePeriod is numeric

## Testing
- pnpm --filter @dokploy/server exec vitest run __test__/mechanizeDockerContainer.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68cdbd7dc32c832f92263883253f7172